### PR TITLE
Fix compatability with day/night update and update YAML dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ packages/**/*
 TestResult.xml
 **/*.csproj.user
 *.nupkg
+.vs
 

--- a/DataFeed.cs
+++ b/DataFeed.cs
@@ -143,10 +143,10 @@ namespace iRacingSDK
 
             try
             {
-                sessionInfoString.Replace(": *", ": ");
+                sessionInfoString = sessionInfoString.Replace(": *", ": ");
                 var input = new StringReader(sessionInfoString);
 
-                var deserializer = new Deserializer(ignoreUnmatched: true);
+                var deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
 
                 var result = (SessionData)deserializer.Deserialize(input, typeof(SessionData));
                 result.Raw = sessionInfoString.Replace("\n", "\r\n");

--- a/DataFeed/GeneratedSessionData.cs
+++ b/DataFeed/GeneratedSessionData.cs
@@ -92,7 +92,7 @@ namespace iRacingSDK
                 public string FogLevel { get; set; }
                 public long Unofficial { get; set; }
                 public string CommercialMode { get; set; }
-                public long NightMode { get; set; }
+                public string NightMode { get; set; }
                 public long IsFixedSetup { get; set; }
                 public string StrictLapsChecking { get; set; }
                 public long HasOpenRegistration { get; set; }

--- a/GenerateDataModels/GenerateDataModels.csproj
+++ b/GenerateDataModels/GenerateDataModels.csproj
@@ -44,8 +44,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="YamlDotNet">
-      <HintPath>..\..\packages\YamlDotNet.3.1.1\lib\net35\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\YamlDotNet.5.3.0\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/GenerateDataModels/packages.config
+++ b/GenerateDataModels/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="YamlDotNet" version="3.1.1" targetFramework="net451" />
+  <package id="YamlDotNet" version="5.3.0" targetFramework="net40-client" />
 </packages>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -48,8 +48,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="YamlDotNet">
-      <HintPath>..\..\packages\YamlDotNet.3.1.1\lib\net35\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\YamlDotNet.5.3.0\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Sample/packages.config
+++ b/Sample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="YamlDotNet" version="3.1.1" targetFramework="net451" />
+  <package id="YamlDotNet" version="5.3.0" targetFramework="net40-client" />
 </packages>

--- a/iRacingSDK.Net.Tests/iRacingSDK.Net.Tests.csproj
+++ b/iRacingSDK.Net.Tests/iRacingSDK.Net.Tests.csproj
@@ -37,8 +37,8 @@
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="YamlDotNet">
-      <HintPath>..\..\packages\YamlDotNet.3.1.1\lib\net35\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\YamlDotNet.5.3.0\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/iRacingSDK.Net.Tests/packages.config
+++ b/iRacingSDK.Net.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="NUnit" version="2.6.3" targetFramework="net451" />
   <package id="NUnit.Runners" version="2.6.3" targetFramework="net451" />
-  <package id="YamlDotNet" version="3.1.1" targetFramework="net451" />
+  <package id="YamlDotNet" version="5.3.0" targetFramework="net40-client" />
 </packages>

--- a/iRacingSDK.csproj
+++ b/iRacingSDK.csproj
@@ -46,8 +46,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="YamlDotNet">
-      <HintPath>..\packages\YamlDotNet.3.1.1\lib\net35\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.5.3.0\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="YamlDotNet" version="3.1.1" targetFramework="net451" />
+  <package id="YamlDotNet" version="5.3.0" targetFramework="net40-client" />
 </packages>


### PR DESCRIPTION
After the day/night update there was a slight change to the
WeekendOptions output. The property "NightMode" can now also take the
value 'variable'. Since the POCO expects a 'long' the deserializer
fails. This has been rectified.

This also fixes issue #6 that I reported a couple of days ago.

As a courtesy I would also like to inform you that if I don't get a response from you before the 28th of December I'll re-publish my modified version of the library on Nuget.